### PR TITLE
Changed "position" to "descendant"

### DIFF
--- a/class2.html
+++ b/class2.html
@@ -187,9 +187,9 @@ img {
         </div>
       </section>  
       
-        <!-- Selector position-->
+        <!-- Selector descendant-->
         <section>
-        <h3>Selector: Position</h3>
+        <h3>Selector: Descendant</h3>
 <pre><code class = "html">
 p em {
   color: yellow;


### PR DESCRIPTION
Calling this selector "position" can make it easily confused with positioning rules like `position: absolute`. I know that "descendant" sounds a little intimidating, but "child" is something else entirely, so hmmmmm...